### PR TITLE
Add support for *.runsettings files

### DIFF
--- a/src/icons.pkgdef
+++ b/src/icons.pkgdef
@@ -446,3 +446,7 @@
 "DefaultIconMoniker"="KnownMonikers.JSONScript"
 [$RootKey$\ShellFileAssociations\.toml]
 "DefaultIconMoniker"="KnownMonikers.JSONScript"
+
+; XML
+[$RootKey$\ShellFileAssociations\.runsettings]
+"DefaultIconMoniker"="KnownMonikers.XMLFile"


### PR DESCRIPTION
Display the "XMLFile" icon for `.runsettings` files used to configure unit tests.