### PR TITLE
Add icon for MSBuild main build script files (.proj)

### DIFF
--- a/src/icons.pkgdef
+++ b/src/icons.pkgdef
@@ -456,3 +456,5 @@
 "DefaultIconMoniker"="KnownMonikers.XMLFile"
 [$RootKey$\ShellFileAssociations\.plist]
 "DefaultIconMoniker"="KnownMonikers.XMLFile"
+[$RootKey$\ShellFileAssociations\.proj]
+"DefaultIconMoniker"="KnownMonikers.XMLFile"


### PR DESCRIPTION
This PR associates the `.proj` file extension (commonly used for MSBuild script files) with the XML icon.