### PR TITLE
Add .yarnignore file icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Road map
 
 - [ ] More icons...
+- [x] .yarnignore file icon
 
 Features that have a checkmark are complete and available for
 download in the
@@ -20,6 +21,7 @@ on the official Visual Studio extension gallery.
 - [x] .asp file icon
 - [x] Help file icons
 - [x] .thift file icon
+- [x] .yarnrc file icon
 
 ## 2.1
 

--- a/FileExtenions.md
+++ b/FileExtenions.md
@@ -1,4 +1,4 @@
-## Supported File Extensions (515)
+## Supported File Extensions (516)
 
 - .7z
 - .accdc
@@ -511,6 +511,7 @@
 - .xz
 - .yaml
 - .yarnclean
+- .yarnignore
 - .yarnrc
 - .yml
 - .zip

--- a/src/icons.pkgdef
+++ b/src/icons.pkgdef
@@ -571,6 +571,8 @@
 "DefaultIconMoniker"="KnownMonikers.DocumentExclude"
 [$RootKey$\ShellFileAssociations\.exclude]
 "DefaultIconMoniker"="KnownMonikers.DocumentExclude"
+[$RootKey$\ShellFileAssociations\.yarnignore]
+"DefaultIconMoniker"="KnownMonikers.DocumentExclude"
 
 ; Images
 [$RootKey$\ShellFileAssociations\.bmp]


### PR DESCRIPTION
Add icon support for the `.yarnignore` file, and add missing `.yarnrc` file to the 2.2 release notes.